### PR TITLE
Missing tutorial 2 scene fix

### DIFF
--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -14,9 +14,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/GlitchEscape/Scenes/Levels/Tutorial/Tutorial_01_Movement.unity
     guid: 73cb27416c21343c1bd684dff607e435
-  - enabled: 0
-    path: 
-    guid: 00000000000000000000000000000000
+  - enabled: 1
+    path: Assets/GlitchEscape/Scenes/Levels/Tutorial/Tutorial_02_Advanced_Movement.unity
+    guid: fe27c2c009534489f9147938aa7e4998
   - enabled: 1
     path: Assets/GlitchEscape/Scenes/Levels/Tutorial/Tutorial_03_Maze_Switch.unity
     guid: d1eb2881f3f3fd142ba12de9a5d03c60

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -14,9 +14,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/GlitchEscape/Scenes/Levels/Tutorial/Tutorial_01_Movement.unity
     guid: 73cb27416c21343c1bd684dff607e435
-  - enabled: 1
-    path: Assets/GlitchEscape/Scenes/Levels/Tutorial/Tutorial_02_Advanced_Movement.unity
-    guid: fe27c2c009534489f9147938aa7e4998
+  - enabled: 0
+    path: 
+    guid: 00000000000000000000000000000000
   - enabled: 1
     path: Assets/GlitchEscape/Scenes/Levels/Tutorial/Tutorial_03_Maze_Switch.unity
     guid: d1eb2881f3f3fd142ba12de9a5d03c60


### PR DESCRIPTION
Added tutorial 2 back into the build list in the correct position and removed the null/deleted listing that was in it's place.