### PR TITLE
new FPS + framerate sampler

### DIFF
--- a/Assets/GlitchEscape/Scripts/Utility/FPSCounter.cs
+++ b/Assets/GlitchEscape/Scripts/Utility/FPSCounter.cs
@@ -1,17 +1,20 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using GlitchEscape.Scripts.Utility;
 using TMPro;
 using UnityEngine;
 
 [RequireComponent(typeof(TextMeshProUGUI))]
 public class FPSCounter : MonoBehaviour {
     [InjectComponent] public TextMeshProUGUI text;
-    private float fps = 60f;
+    private FramerateSampler framerateSampler { get; } = new FramerateSampler();
+    public float currentFramerate => framerateSampler.framerate;
     void Update() {
-        var step = 0.1f;
-        if (Time.deltaTime > 0f) {
-            fps = fps * (1f - step) + step / Time.deltaTime;
-            text.text = "FPS: " + Mathf.Round(fps);
-        }
+        framerateSampler.Update();
+        text.text = "FPS: " + Mathf.Round(currentFramerate) + "\n" + (1f / Time.smoothDeltaTime) + "\n" + Time.unscaledDeltaTime;
+    }
+
+    void OnGUI() {
+        GUILayout.Label("\n\n\n\n\n\n\n" +  Mathf.Round(currentFramerate) + "\n" + (1f / Time.smoothDeltaTime) + "\n" + Time.unscaledDeltaTime);
     }
 }

--- a/Assets/GlitchEscape/Scripts/Utility/FPSCounter.cs
+++ b/Assets/GlitchEscape/Scripts/Utility/FPSCounter.cs
@@ -11,10 +11,14 @@ public class FPSCounter : MonoBehaviour {
     public float currentFramerate => framerateSampler.framerate;
     void Update() {
         framerateSampler.Update();
-        text.text = "FPS: " + Mathf.Round(currentFramerate) + "\n" + (1f / Time.smoothDeltaTime) + "\n" + Time.unscaledDeltaTime;
+        if (framerateSampler.hasSamples) {
+            text.text = "FPS: " + Mathf.Round(currentFramerate);
+                        // + "\n" + (1f / Time.smoothDeltaTime) + "\n" + Time.unscaledDeltaTime;
+        } else {
+            text.text = "";
+        }
     }
-
-    void OnGUI() {
-        GUILayout.Label("\n\n\n\n\n\n\n" +  Mathf.Round(currentFramerate) + "\n" + (1f / Time.smoothDeltaTime) + "\n" + Time.unscaledDeltaTime);
-    }
+    // void OnGUI() {
+    //     GUILayout.Label("\n\n\n\n\n\n\n" +  Mathf.Round(currentFramerate) + "\n" + (1f / Time.smoothDeltaTime) + "\n" + Time.unscaledDeltaTime);
+    // }
 }

--- a/Assets/GlitchEscape/Scripts/Utility/FramerateSampler.cs
+++ b/Assets/GlitchEscape/Scripts/Utility/FramerateSampler.cs
@@ -24,17 +24,21 @@ namespace GlitchEscape.Scripts.Utility {
             nextSampleIndex = (nextSampleIndex + 1) % ((uint) samples.Length);
         }
         public float average => currentSampleTotal / numSamples;
+        public uint sampleCount => numSamples;
     }
     
     public class FramerateSampler {
         private RingBufferAverageSampler dtSamples { get; } = new RingBufferAverageSampler(64);
+        private uint skipFrames = 4;     // skip first N frames
 
         /// <summary>
         /// Should be called every frame
         /// </summary>
         public void Update() {
-            dtSamples.AddSample(Time.unscaledDeltaTime);
+            if (skipFrames > 0) --skipFrames;
+            else dtSamples.AddSample(Time.unscaledDeltaTime);
         }
-        public float framerate => 1f / dtSamples.average;
+        public float framerate => dtSamples.sampleCount > 0 ? 1f / dtSamples.average : 0f;
+        public bool hasSamples => dtSamples.sampleCount > 0;
     }
 }

--- a/Assets/GlitchEscape/Scripts/Utility/FramerateSampler.cs
+++ b/Assets/GlitchEscape/Scripts/Utility/FramerateSampler.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+namespace GlitchEscape.Scripts.Utility {
+    /// <summary>
+    /// Stores floating point samples + calculates a running average of submitted samples
+    /// used to implement <see cref="FramerateSampler"/>
+    /// </summary>
+    public class RingBufferAverageSampler {
+        private float[] samples;
+        private uint  numSamples = 0;
+        private float currentSampleTotal = 0f;
+        private uint  nextSampleIndex = 0;
+
+        public RingBufferAverageSampler(uint numSamples = 64) {
+            this.samples = new float[numSamples];
+        }
+        public void AddSample(float sample) {
+            if (numSamples >= samples.Length) {
+                currentSampleTotal -= samples[nextSampleIndex];
+            } else {
+                ++numSamples;
+            }
+            currentSampleTotal += samples[nextSampleIndex] = sample;
+            nextSampleIndex = (nextSampleIndex + 1) % ((uint) samples.Length);
+        }
+        public float average => currentSampleTotal / numSamples;
+    }
+    
+    public class FramerateSampler {
+        private RingBufferAverageSampler dtSamples { get; } = new RingBufferAverageSampler(64);
+
+        /// <summary>
+        /// Should be called every frame
+        /// </summary>
+        public void Update() {
+            dtSamples.AddSample(Time.unscaledDeltaTime);
+        }
+        public float framerate => 1f / dtSamples.average;
+    }
+}

--- a/Assets/GlitchEscape/Scripts/Utility/FramerateSampler.cs.meta
+++ b/Assets/GlitchEscape/Scripts/Utility/FramerateSampler.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4d4544afc4b54037bd8d98ba9548cfd0
+timeCreated: 1591355537

--- a/Assets/GlitchEscape/Scripts/Utility/FramerateSampler.cs.meta
+++ b/Assets/GlitchEscape/Scripts/Utility/FramerateSampler.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 4d4544afc4b54037bd8d98ba9548cfd0
-timeCreated: 1591355537
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
note: fwiw, low framerate in editor is the ACTUAL framerate, but the framerate displayed in stats is a simulated / inferred framerate that removes the unity editor's overhead. As such that is much higher, and is more or less reflective of the actual framerate in a build / etc.

That said this is still an improvement and the framerate sample is being used for other performance testing tools.