### PR TITLE
Floating npcs

### DIFF
--- a/Assets/GlitchEscape/Prefabs/Environment/Humantank.prefab
+++ b/Assets/GlitchEscape/Prefabs/Environment/Humantank.prefab
@@ -679,7 +679,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3424189200679815514}
   m_LocalRotation: {x: -0.000000081460335, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.00208584, y: 0.055048477, z: 0.007337632}
+  m_LocalPosition: {x: -0.00208584, y: 0.053244695, z: 0.007337632}
   m_LocalScale: {x: 0.06269814, y: 0.06269814, z: 0.06269814}
   m_Children:
   - {fileID: 1410307687897257869}
@@ -703,6 +703,7 @@ MonoBehaviour:
   cycleDuration: 10
   floatOffsetDistance: 0.05
   randomizeFloatStartTimes: 1
+  noiseOctaveStrengths: []
 --- !u!1 &6913526292688088397
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/GlitchEscape/Prefabs/Environment/Humantank.prefab
+++ b/Assets/GlitchEscape/Prefabs/Environment/Humantank.prefab
@@ -548,9 +548,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e477fd7ef77eb74081e51f41e5456b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  player: {fileID: 0}
   dialogManager: {fileID: 0}
   inputText: {fileID: 0}
   speakerName: 
+  postOrbSpeaker: 
+  isTank: 0
+  turnSpeed: 0
+  wanderRange: 0
+  minIdle: 0
+  maxIdle: 0
+  virtueType: 0
 --- !u!114 &2081035318876736062
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -563,6 +571,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b249d16000923413789e27bc0b143f0d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  changeToXbox: 0
+  xbox_message: 
   keyboard_message: <sprite=1> talk to
   controller_message: <sprite=6> talk to
 --- !u!1 &3052710148014902178
@@ -653,6 +663,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1864050679344610121}
+  - component: {fileID: 6520072476006863915}
   m_Layer: 0
   m_Name: UnriggedPlayerModel
   m_TagString: Untagged
@@ -668,7 +679,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3424189200679815514}
   m_LocalRotation: {x: -0.000000081460335, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.00208584, y: 0.056057163, z: 0.007337623}
+  m_LocalPosition: {x: -0.00208584, y: 0.055048477, z: 0.007337632}
   m_LocalScale: {x: 0.06269814, y: 0.06269814, z: 0.06269814}
   m_Children:
   - {fileID: 1410307687897257869}
@@ -677,6 +688,21 @@ Transform:
   m_Father: {fileID: 4084319799728546045}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6520072476006863915
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3424189200679815514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e099666e604bc474084e7e3869b90ae9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cycleDuration: 10
+  floatOffsetDistance: 0.05
+  randomizeFloatStartTimes: 1
 --- !u!1 &6913526292688088397
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/GlitchEscape/Scripts/Misc/FloatingObject.cs
+++ b/Assets/GlitchEscape/Scripts/Misc/FloatingObject.cs
@@ -7,7 +7,9 @@ using Random = UnityEngine.Random;
 [ExecuteInEditMode]
 public class FloatingObject : MonoBehaviour {
     private Vector3 centerPosition;
+    private Quaternion initialRotation;
     private float startTime;
+    private float rotationTimeOffset;
 
     private void OnEnable() {
         Setup();
@@ -18,15 +20,26 @@ public class FloatingObject : MonoBehaviour {
         if (randomizeFloatStartTimes) {
             startTime += Random.Range(-cycleDuration, +cycleDuration);
         }
+        initialRotation = transform.rotation;
+        rotationTimeOffset = Random.Range(-rotationCycleDuration, +rotationCycleDuration);
     }
     
     public float cycleDuration = 10f;
     public float floatOffsetDistance = 0.05f;
     public bool randomizeFloatStartTimes;
+    public bool applyRotation = true;
+    public float rotationCycleDuration = 4f;
+    public float rotationDegrees = 15f;
     
     void Update() {
         var t = (Time.time - startTime) / cycleDuration;
         var cycle = Mathf.Sin(t * Mathf.PI * 2f);
         transform.position = centerPosition + Vector3.up * cycle * floatOffsetDistance;
+
+        if (applyRotation) {
+            var t2 = (Time.time - startTime + rotationTimeOffset) / rotationCycleDuration;
+            var angle = Mathf.Sin(t2 * Mathf.PI * 2f) * rotationDegrees;
+            transform.rotation = initialRotation * Quaternion.AngleAxis(angle, Vector3.up);
+        }
     }
 }

--- a/Assets/GlitchEscape/Scripts/Misc/FloatingObject.cs
+++ b/Assets/GlitchEscape/Scripts/Misc/FloatingObject.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+[ExecuteInEditMode]
+public class FloatingObject : MonoBehaviour {
+    private Vector3 centerPosition;
+    private float startTime;
+
+    private void OnEnable() {
+        Setup();
+    }
+    public void Setup() {
+        centerPosition = transform.position; 
+        startTime = Time.time;
+        if (randomizeFloatStartTimes) {
+            startTime += Random.Range(-cycleDuration, +cycleDuration);
+        }
+    }
+    
+    public float cycleDuration = 1f;
+    public float floatOffsetDistance = 0.2f;
+    public bool randomizeFloatStartTimes;
+    
+    void Update() {
+        var t = (Time.time - startTime) / cycleDuration;
+        var cycle = Mathf.Sin(t * Mathf.PI * 2f);
+        transform.position = centerPosition + Vector3.up * cycle * floatOffsetDistance;
+    }
+}

--- a/Assets/GlitchEscape/Scripts/Misc/FloatingObject.cs
+++ b/Assets/GlitchEscape/Scripts/Misc/FloatingObject.cs
@@ -20,8 +20,8 @@ public class FloatingObject : MonoBehaviour {
         }
     }
     
-    public float cycleDuration = 1f;
-    public float floatOffsetDistance = 0.2f;
+    public float cycleDuration = 10f;
+    public float floatOffsetDistance = 0.05f;
     public bool randomizeFloatStartTimes;
     
     void Update() {

--- a/Assets/GlitchEscape/Scripts/Misc/FloatingObject.cs.meta
+++ b/Assets/GlitchEscape/Scripts/Misc/FloatingObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e099666e604bc474084e7e3869b90ae9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- adds a script that makes NPCs float in their tanks in the hub level
- sinusoidal movement with a vertical component, and an optional yaw rotation component, and different frequencies
- easily tweakable, although the current settings look good enough (TM)
- NOT applied to any of the other cutscene hub scenes (doing so would take way too much time), so... well, the player _probably_ won't notice
(okay, actually this would be doable if the NPCs were all prefabs, but unfortunately they're not so I'd have to hand edit all the scenes either way to add floating motion to all of them)